### PR TITLE
Fix Vercel build: set framework to null for static site deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "version": 2,
+  "framework": null,
   "buildCommand": null,
+  "outputDirectory": ".",
   "installCommand": "npm install",
   "functions": {
     "api/index.js": {


### PR DESCRIPTION
Vercel was failing with 'No entrypoint found' because it was trying to
detect a framework from package.json. Setting framework: null and
outputDirectory: . tells Vercel to serve static files + serverless functions.

https://claude.ai/code/session_01LRuqEeNnUTEdx41PQN8diQ